### PR TITLE
MultiTransfer: remove 'amountIn' check parameter

### DIFF
--- a/contracts/MultiTransfer.sol
+++ b/contracts/MultiTransfer.sol
@@ -14,25 +14,18 @@ contract MultiTransfer is IMultiTransfer {
     /// @return true/false
     function multiTransfer(
         address erc20,
-        uint256 amountIn,
         uint256[] calldata bits
     ) external override returns (bool) {
         require(erc20 != address(0), "ERC20 address invalid");
-        require(amountIn != 0, "Input amount invalid");
 
         IERC20 token = IERC20(erc20);
-        uint256 totalOut = 0;
 
         // output amount to recipients
         for (uint256 i = 0; i < bits.length; i++) {
             address a = address(bits[i] >> 96);
             uint256 amount = bits[i] & ((1 << 96) - 1);
             token.safeTransferFrom(msg.sender, a, amount);
-
-            totalOut += amount;
         }
-
-        require(amountIn == totalOut, "Output amt must equal input amt");
 
         return true;
     }

--- a/contracts/interfaces/IMultiTransfer.sol
+++ b/contracts/interfaces/IMultiTransfer.sol
@@ -5,7 +5,6 @@ pragma solidity 0.6.12;
 interface IMultiTransfer {
     function multiTransfer(
         address erc20,
-        uint256 amountIn,
         uint256[] calldata bits
     ) external returns (bool);
 }

--- a/test/MultiTransfer.js
+++ b/test/MultiTransfer.js
@@ -23,19 +23,11 @@ contract('MultiTransfer', async accounts => {
   })
 
   it('reverts if ERC20 address is zero', async () => {
-    await expectRevert(mt.multiTransfer(constants.ZERO_ADDRESS, 1000, [], {from: sender}), 'ERC20 address invalid')
+    await expectRevert(mt.multiTransfer(constants.ZERO_ADDRESS, [], {from: sender}), 'ERC20 address invalid')
   })
 
-  it('reverts if amount is zero', async () => {
-    await expectRevert(mt.multiTransfer(erc20.address, 0, [], {from: sender}), 'Input amount invalid')
-  })
-
-  it('reverts if total is less than amount', async () => {
-    await expectRevert(mt.multiTransfer(erc20.address, 1000, [e(receiver1, 500), e(receiver2, 300), e(receiver3, 199)], {from: sender}), 'Output amt must equal input amt')
-  })
-
-  it('reverts if total is more than amount', async () => {
-    await expectRevert(mt.multiTransfer(erc20.address, 999, [e(receiver1, 500), e(receiver2, 300), e(receiver3, 200)], {from: sender}), 'Output amt must equal input amt')
+  it('reverts if amount sent is too large', async () => {
+    await expectRevert(mt.multiTransfer(erc20.address, [e(receiver1, 500), e(receiver2, 1300), e(receiver3, 200)], {from: sender}), 'ERC20: transfer amount exceeds balance')
   })
 
   it('balances are correct', async () => {
@@ -43,7 +35,7 @@ contract('MultiTransfer', async accounts => {
     assert.equal(await erc20.balanceOf(receiver1), 0)
     assert.equal(await erc20.balanceOf(receiver2), 0)
     assert.equal(await erc20.balanceOf(receiver3), 0)
-    await mt.multiTransfer(erc20.address, 1000, [e(receiver1, 500), e(receiver2, 300), e(receiver3, 200)], {from: sender})
+    await mt.multiTransfer(erc20.address, [e(receiver1, 500), e(receiver2, 300), e(receiver3, 200)], {from: sender})
     assert.equal(await erc20.balanceOf(sender), 0)
     assert.equal(await erc20.balanceOf(receiver1), 500)
     assert.equal(await erc20.balanceOf(receiver2), 300)


### PR DESCRIPTION
This was not required, and will revert anyway if under-funded.
Therefore, removed, to save gas.