### PR TITLE
Holding memo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,43 +18,46 @@ Then, at any time, users may claim their XYZ tokens by providing a
 Merkle proof of their (address,amount).
 
 The end result is aggregating all the payouts into a single blockchain
-transaction _from the funder_.  (Users must still individually issue
+transaction _from the funder_. (Users must still individually issue
 claim transactions)
 
 ## Public operations (APIs)
 
-### Anyone:  Validate claim
+### Anyone: Validate claim
 
 Validate a supplied merkle receipt is associated with a valid, unspent claim.
 
-### Anyone:   Claim tokens
+### Anyone: Claim tokens
 
 Present a valid merkle receipt with account associated with it and transfer the associated tokens to given account.
 
 Provided account address must be the address in the claim, and the claim must be unspent.
 
-### Funder:  Create new claims group
+### Funder: Create new claims group
 
 Store a merkle root, and associated ERC20 funds, on chain.
 Must provide withdraw unlock time and its value must be atleast 30 days higher than claim group create time. 
 
-**WARNING**:  There is no on-chain validation that funds supplied equal the
-funds required to fully satisfy all claims.  The funder may under-fund.
+Can also provide a memo string for adding arbitrary notes to the group.
+
+**WARNING**: There is no on-chain validation that funds supplied equal the
+funds required to fully satisfy all claims. The funder may under-fund.
+
 > Funder can not claim tokens via `claim()`
 
-### Anyone:  Add more funds to claims group.
+### Anyone: Add more funds to claims group.
 
 Supply additional quantity of asset to the claims group.
 
 Usually the funder calls this operation, but that is not a requirement.
 Once a claims group is created, anyone may supply additional funds.
 
-### Funder:  Withdraw funds from claims group.
+### Funder: Withdraw funds from claims group.
 
 The funder (owner) may withdraw funds from the claims group,
 if-and-only-if the Withdraw Unlock time is reached.
 
-### Anyone:  On-chain ERC20 mass-send
+### Anyone: On-chain ERC20 mass-send
 
 A separate MultiTransfer contract is provided, which provides the
 simple utility of
@@ -71,7 +74,7 @@ operation for ERC20 tokens.
 ### Under-funding
 
 It appears prohibitively expensive to validate that a holding is fully
-funded.  (Solutions welcome)
+funded. (Solutions welcome)
 
 As a consequence, it is possible to under-fund a claims group.
 
@@ -84,18 +87,25 @@ There will be atleast 30 days withdraw locking. To permanently lock the funds, s
 maximum, or an arbitrary time millions of years in the future.
 
 ## Setup.
+
 1. Install packages
+
    ```
    npm i -g truffle
    npm i
    ```
+
 2. Update provider url in config/default.json
+
 3. Set DEPLOYMENT_ACCOUNT_KEY in env
+
    ```
    create a .env file in root
    DEPLOYMENT_ACCOUNT_KEY =  "my mnemonic phrase"
    ```
+
 4. Deploy you own contracts if want to do arb- 
+
    ``` 
    truffle migrate --reset --network mainnet/ropsten
    ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Provided account address must be the address in the claim, and the claim must be
 ### Funder: Create new claims group
 
 Store a merkle root, and associated ERC20 funds, on chain.
-Must provide withdraw unlock time and its value must be atleast 30 days higher than claim group create time. 
+Must provide withdraw unlock time and its value must be atleast 30 days higher than claim group create time.
 
 Can also provide a memo string for adding arbitrary notes to the group.
 
@@ -104,8 +104,18 @@ maximum, or an arbitrary time millions of years in the future.
    DEPLOYMENT_ACCOUNT_KEY =  "my mnemonic phrase"
    ```
 
-4. Deploy you own contracts if want to do arb- 
+4. Deploy you own contracts if want to do arb-
 
-   ``` 
+   ```
    truffle migrate --reset --network mainnet/ropsten
    ```
+
+## Test
+
+Create a `.env` file and define: `NODE_BASE_URL` and `DEPLOYMENT_ACCOUNT_KEY`.
+
+```sh
+source .env && npm run fork:start
+npm test
+npm run fork:stop
+```

--- a/contracts/MerkleBox.sol
+++ b/contracts/MerkleBox.sol
@@ -20,6 +20,7 @@ contract MerkleBox is IMerkleBox {
         uint256 balance; // amount of token held currently
         bytes32 merkleRoot; // root of claims merkle tree
         uint256 withdrawUnlockTime; // withdraw forbidden before this time
+        string memo; // an string to store arbitary notes about the holding
     }
 
     mapping(uint256 => Holding) public holdings;
@@ -116,7 +117,8 @@ contract MerkleBox is IMerkleBox {
         address erc20,
         uint256 amount,
         bytes32 merkleRoot,
-        uint256 withdrawUnlockTime
+        uint256 withdrawUnlockTime,
+        string calldata memo
     ) external override returns (uint256) {
         // prelim. parameter checks
         require(erc20 != address(0), "Invalid ERC20 address");
@@ -145,8 +147,9 @@ contract MerkleBox is IMerkleBox {
         holding.balance = amount;
         holding.merkleRoot = merkleRoot;
         holding.withdrawUnlockTime = withdrawUnlockTime;
+        holding.memo = memo;
         claimGroupIds[msg.sender].push(claimGroupCount);
-        emit NewMerkle(msg.sender, erc20, amount, merkleRoot, claimGroupCount, withdrawUnlockTime);
+        emit NewMerkle(msg.sender, erc20, amount, merkleRoot, claimGroupCount, withdrawUnlockTime, memo);
         return claimGroupCount;
     }
 

--- a/contracts/interfaces/IMerkleBox.sol
+++ b/contracts/interfaces/IMerkleBox.sol
@@ -9,7 +9,8 @@ interface IMerkleBox {
         uint256 amount,
         bytes32 indexed merkleRoot,
         uint256 claimGroupId,
-        uint256 withdrawUnlockTime
+        uint256 withdrawUnlockTime,
+        string memo
     );
     event MerkleClaim(address indexed account, address indexed erc20, uint256 amount);
     event MerkleFundUpdate(address indexed funder, bytes32 indexed merkleRoot, uint256 claimGroupId, uint256 amount, bool withdraw);
@@ -32,7 +33,8 @@ interface IMerkleBox {
         address erc20,
         uint256 amount,
         bytes32 merkleRoot,
-        uint256 withdrawUnlockTime
+        uint256 withdrawUnlockTime,
+        string calldata memo
     ) external returns (uint256);
 
     function isClaimable(

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test": "test"
   },
   "scripts": {
+    "fork:start": "npx ganache-cli --fork $NODE_BASE_URL --host 0.0.0.0 --mnemonic $DEPLOYMENT_ACCOUNT_KEY &",
+    "fork:stop": "kill -TERM $(lsof -i :8545 -s TCP:LISTEN -t)",
     "ganache-cli": "ganache-cli",
     "lint": "eslint ./test/*",
     "lint:fix": "eslint --fix ./test --ext .js",

--- a/test/MerkleBox.js
+++ b/test/MerkleBox.js
@@ -58,14 +58,15 @@ contract('MerkleBox', async (accounts) => {
 
     it('emits NewMerkle event and deposits funds', async () => {
       await erc20.approve(merkleBox.address, 1000, {from: funder})
-      const tx = await merkleBox.newClaimsGroup(erc20.address, 1000, merkleRoot, unlockTime, {from: funder})
+      const tx = await merkleBox.newClaimsGroup(erc20.address, 1000, merkleRoot, unlockTime, 'datasetUri=http://test.com/json', {from: funder})
       expectEvent(tx, 'NewMerkle', {
         sender: funder,
         erc20: erc20.address,
         amount: new BN(1000),
         merkleRoot: merkleRoot,
         claimGroupId: new BN(1),
-        withdrawUnlockTime: unlockTime
+        withdrawUnlockTime: unlockTime,
+        memo: 'datasetUri=http://test.com/json'
       })
       assert.equal(await erc20.balanceOf(funder), 0)
       assert.equal(await erc20.balanceOf(merkleBox.address), 1000)
@@ -73,28 +74,28 @@ contract('MerkleBox', async (accounts) => {
 
     it('reverts if ERC20 address is zero', async () => {
       await erc20.approve(merkleBox.address, 1000, {from: funder})
-      await expectRevert(merkleBox.newClaimsGroup(constants.ZERO_ADDRESS, 1000, merkleRoot, unlockTime, {from: funder}), 'Invalid ERC20 address')
+      await expectRevert(merkleBox.newClaimsGroup(constants.ZERO_ADDRESS, 1000, merkleRoot, unlockTime, '', {from: funder}), 'Invalid ERC20 address')
     })
 
     it('reverts if merkleRoot is zero', async () => {
       await erc20.approve(merkleBox.address, 1000, {from: funder})
-      await expectRevert(merkleBox.newClaimsGroup(erc20.address, 1000, constants.ZERO_ADDRESS, unlockTime, {from: funder}), 'Merkle cannot be zero')
+      await expectRevert(merkleBox.newClaimsGroup(erc20.address, 1000, constants.ZERO_ADDRESS, unlockTime, '', {from: funder}), 'Merkle cannot be zero')
     })
 
     it('reverts if withdraw lock time is less than minimum', async () => {
       const errorMessage = 'Holing lock must exceed minimum lock period.'
       await erc20.approve(merkleBox.address, 1000, {from: funder})
-      await expectRevert(merkleBox.newClaimsGroup(erc20.address, 1000, merkleRoot, 0, {from: funder}), errorMessage)
+      await expectRevert(merkleBox.newClaimsGroup(erc20.address, 1000, merkleRoot, 0, '', {from: funder}), errorMessage)
     })
 
     it('reverts if insufficient balance', async () => {
       await erc20.approve(merkleBox.address, 1000, {from: funder})
-      await expectRevert(merkleBox.newClaimsGroup(erc20.address, 1001, merkleRoot, unlockTime, {from: funder}), 'Insufficient balance')
+      await expectRevert(merkleBox.newClaimsGroup(erc20.address, 1001, merkleRoot, unlockTime, '', {from: funder}), 'Insufficient balance')
     })
 
     it('reverts if amount is zero', async () => {
       await erc20.approve(merkleBox.address, 1000, {from: funder})
-      await expectRevert(merkleBox.newClaimsGroup(erc20.address, 0, merkleRoot, unlockTime, {from: funder}), 'Amount cannot be zero')
+      await expectRevert(merkleBox.newClaimsGroup(erc20.address, 0, merkleRoot, unlockTime, '', {from: funder}), 'Amount cannot be zero')
     })
   })
 
@@ -105,8 +106,8 @@ contract('MerkleBox', async (accounts) => {
 
     beforeEach(async () => {
       await erc20.approve(merkleBox.address, 1000, {from: funder})
-      claimGroupId = await merkleBox.newClaimsGroup.call(erc20.address, 1000, merkleRoot, unlockTime, {from: funder})
-      await merkleBox.newClaimsGroup(erc20.address, 1000, merkleRoot, unlockTime, {from: funder})
+      claimGroupId = await merkleBox.newClaimsGroup.call(erc20.address, 1000, merkleRoot, unlockTime, '', {from: funder})
+      await merkleBox.newClaimsGroup(erc20.address, 1000, merkleRoot, unlockTime, '', {from: funder})
     })
 
     it('funder cannot withdraw', async () => {
@@ -115,8 +116,8 @@ contract('MerkleBox', async (accounts) => {
 
     it('should get list of claim ids', async () => {
       await erc20.approve(merkleBox.address, 1000, {from: funder2})
-      await merkleBox.newClaimsGroup(erc20.address, 500, merkleRoot, unlockTime, {from: funder2})
-      await merkleBox.newClaimsGroup(erc20.address, 500, merkleRoot, unlockTime, {from: funder2})
+      await merkleBox.newClaimsGroup(erc20.address, 500, merkleRoot, unlockTime, '', {from: funder2})
+      await merkleBox.newClaimsGroup(erc20.address, 500, merkleRoot, unlockTime, '', {from: funder2})
       const ids = await merkleBox.getClaimGroupIds(funder2)
       assert.equal(ids.length, '2', 'claimGroupIds list is wrong')
     })
@@ -288,7 +289,7 @@ contract('MerkleBox', async (accounts) => {
 
     it('can create a second claims group with the same Merkle root', async () => {
       await erc20.approve(merkleBox.address, 1000, {from: funder2})
-      const tx = await merkleBox.newClaimsGroup(erc20.address, 1000, merkleRoot, unlockTime, {from: funder2})
+      const tx = await merkleBox.newClaimsGroup(erc20.address, 1000, merkleRoot, unlockTime, '', {from: funder2})
       expectEvent(tx, 'NewMerkle', {
         sender: funder2,
         erc20: erc20.address,
@@ -309,8 +310,8 @@ contract('MerkleBox', async (accounts) => {
 
     beforeEach(async () => {
       await erc20.approve(merkleBox.address, 29, {from: funder})
-      claimGroupId = await merkleBox.newClaimsGroup.call(erc20.address, 29, merkleRoot, unlockTime, {from: funder})
-      await merkleBox.newClaimsGroup(erc20.address, 29, merkleRoot, unlockTime, {from: funder})
+      claimGroupId = await merkleBox.newClaimsGroup.call(erc20.address, 29, merkleRoot, unlockTime, '', {from: funder})
+      await merkleBox.newClaimsGroup(erc20.address, 29, merkleRoot, unlockTime, '', {from: funder})
       const proof = merkleTree.getHexProof(receipt(recipient2, 20))
       await merkleBox.claim(claimGroupId, recipient2, 20, proof, {from: recipient2})
     })
@@ -337,8 +338,8 @@ contract('MerkleBox', async (accounts) => {
 
     beforeEach(async () => {
       await erc20.approve(merkleBox.address, 30, {from: funder})
-      claimGroupId = await merkleBox.newClaimsGroup.call(erc20.address, 30, merkleRoot, unlockTime, {from: funder})
-      await merkleBox.newClaimsGroup(erc20.address, 30, merkleRoot, unlockTime, {from: funder})
+      claimGroupId = await merkleBox.newClaimsGroup.call(erc20.address, 30, merkleRoot, unlockTime, '', {from: funder})
+      await merkleBox.newClaimsGroup(erc20.address, 30, merkleRoot, unlockTime, '', {from: funder})
     })
 
     it('reverts when holding owner tries to claim', async () => {
@@ -359,10 +360,10 @@ contract('MerkleBox', async (accounts) => {
 
     beforeEach(async () => {
       await erc20.approve(merkleBox.address, 1000, {from: funder})
-      claimGroupId1 = await merkleBox.newClaimsGroup.call(erc20.address, 500, merkleRoot, unlockTime, {from: funder})
-      await merkleBox.newClaimsGroup(erc20.address, 500, merkleRoot, unlockTime, {from: funder})
-      claimGroupId2 = await merkleBox.newClaimsGroup.call(erc20.address, 500, merkleRoot, unlockTime, {from: funder})
-      await merkleBox.newClaimsGroup(erc20.address, 500, merkleRoot, unlockTime, {from: funder})
+      claimGroupId1 = await merkleBox.newClaimsGroup.call(erc20.address, 500, merkleRoot, unlockTime, '', {from: funder})
+      await merkleBox.newClaimsGroup(erc20.address, 500, merkleRoot, unlockTime, '', {from: funder})
+      claimGroupId2 = await merkleBox.newClaimsGroup.call(erc20.address, 500, merkleRoot, unlockTime, '', {from: funder})
+      await merkleBox.newClaimsGroup(erc20.address, 500, merkleRoot, unlockTime, '', {from: funder})
     })
 
     it('isClaimable() returns true for recipient in both claim groups', async () => {


### PR DESCRIPTION
Add a `memo` param to `newClaimsGroup`.

The motivation is to help creating simpler claim workflows for the users by storing on-chain small pieces of information like the URI where all the (account -> amount, proof) tuples are stored (off-chain).